### PR TITLE
Added CC and BCC recipients

### DIFF
--- a/Sources/EmailComposer/EmailComposerView.swift
+++ b/Sources/EmailComposer/EmailComposerView.swift
@@ -22,6 +22,8 @@ struct EmailComposerView: UIViewControllerRepresentable {
         emailComposer.mailComposeDelegate = context.coordinator
         emailComposer.setSubject(emailData.subject)
         emailComposer.setToRecipients(emailData.recipients)
+        emailComposer.setCcRecipients(emailData.ccRecipients)
+        emailComposer.setBccRecipients(emailData.bccRecipients)
         emailComposer.setMessageBody(emailData.body, isHTML: emailData.isBodyHTML)
         if emailData.attachments.count > 0 {
             for attachment in emailData.attachments {

--- a/Sources/EmailComposer/EmailData.swift
+++ b/Sources/EmailComposer/EmailData.swift
@@ -19,6 +19,12 @@ public struct EmailData {
     
     /// The potential recipients of the email.
     public var recipients: [String]?
+
+    /// The potential carbon copy (CC) recipients of the email.
+    public var ccRecipients: [String]?
+
+    /// The potential blind carbon copy (BCC) recipients of the email.
+    public var bccRecipients: [String]?
     
     /// The email body.
     ///


### PR DESCRIPTION
Our business has a requirement at times to include carbon copy (CC) and blind carbon copy (BCC) recipients to emails sent from our apps. This functionality appears to be missing so I've included these two optional properties in EmailData.